### PR TITLE
Get service name and Validate message methods implementation (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.9
+- Implemented getServiceName and added remrem-protocol-interface
+
 ## 0.1.8
 - added getEventId functionality for get the event id from the json Object
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ jar {
 
 shadowJar {
     baseName = 'eiffel-remrem-semantics'
-    version =  '0.1.8'
+    version =  '0.1.9'
     classifier = ''
 }
 
@@ -64,7 +64,8 @@ repositories {
 install.dependsOn shadowJar
 
 dependencies {
-    compile 'com.github.Ericsson:eiffel-remrem-shared:0.1.5'    
+    compile 'com.github.Ericsson:eiffel-remrem-shared:0.2.0' 
+    compile 'com.github.Ericsson:eiffel-remrem-protocol-interface:0.0.1'    
     compile('com.github.fge:json-schema-validator:2.2.6')
     {
     // we need to exclude jackson-databind here and add a

--- a/src/test/java/com/ericsson/eiffel/remrem/semantics/ServiceTest.java
+++ b/src/test/java/com/ericsson/eiffel/remrem/semantics/ServiceTest.java
@@ -1,21 +1,27 @@
 package com.ericsson.eiffel.remrem.semantics;
 
-import com.ericsson.eiffel.remrem.semantics.events.EiffelActivityFinishedEvent;
-import com.ericsson.eiffel.remrem.semantics.events.EiffelArtifactPublishedEvent;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InjectMocks;
-import static org.mockito.Mockito.*;
-
-import org.mockito.MockitoAnnotations;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.jar.Attributes;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import com.ericsson.eiffel.remrem.protocol.ValidationResult;
+import com.ericsson.eiffel.remrem.semantics.events.EiffelActivityFinishedEvent;
+import com.ericsson.eiffel.remrem.semantics.events.EiffelArtifactPublishedEvent;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 public class ServiceTest {
 
@@ -96,5 +102,24 @@ public class ServiceTest {
         } catch(FileNotFoundException e) {
             Assert.assertFalse(false);
         }
+    }
+
+    @Test
+    public void validateMessage() {
+        File file = new File(getClass().getClassLoader().getResource("output/ActivityFinished.json").getFile());
+        JsonObject input;
+        ValidationResult msg = null;
+        try {
+            input = parser.parse(new FileReader(file)).getAsJsonObject();
+            msg = service.validateMsg(ACTIVITY_FINISHED, input);
+        } catch (JsonIOException e) {
+            e.printStackTrace();
+        } catch (JsonSyntaxException e) {
+            e.printStackTrace();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        Assert.assertNotNull(msg);
+        Assert.assertTrue(msg.isValid());
     }
 }


### PR DESCRIPTION
* Added getServiceName and validateMsg methods

* removed try and catch outPutValidate method

* changed getServiceName return eiffel-semantics to eiffelsemantics

* Created constants for all hard coded strings.